### PR TITLE
Fix github hover

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -640,6 +640,15 @@ footer {
     position: relative;
 }
 
+.github-dropdown-content::before {
+    content: '';
+    position: absolute;
+    top: -0.5rem;
+    left: 0;
+    right: 0;
+    height: 0.5rem;
+}
+
 .github-dropdown-content {
     display: none;
     position: absolute;


### PR DESCRIPTION
Hey there,

Was browsing the website and noticed that the GH repos are not accessible from the dropdown:

This PR just adds a before element to make the gap between the nav "GitHub" text and the hovering contents be small:

https://github.com/user-attachments/assets/c12779d5-6767-4be2-8ca1-264a8b1c7478

Tested this with 

```
uv run -m http.server .
```

